### PR TITLE
Dist assets directory

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -22,5 +22,6 @@ class Plugin extends Plugin_Base {
 		( new Router() )->init();
 		( new Template() )->init();
 		( new Override() )->init();
+		( new Settings() )->init();
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class Settings file
+ *
+ * @package WpEasy
+ */
+
+namespace WpEasy;
+
+/**
+ * Class Settings
+ *
+ * @package WpEasy
+ */
+class Settings {
+
+	/**
+	 * Init function
+	 */
+	public function init() {
+		add_action( 'admin_bar_menu', array( $this, 'add_purge_link' ), 1000 );
+	}
+
+	public function add_purge_link( $admin_bar ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return; // security check.
+		}
+
+		$current_url = (isset($_SERVER['HTTPS']) ? "https://" : "http://") . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+
+		// Parse the URL into components
+		$url_parts = parse_url($current_url);
+		
+		// Parse existing query parameters
+		parse_str($url_parts['query'] ?? '', $query_params);
+
+		// Add/modify the parameter
+		$query_params[$param_name] = $param_value;
+
+		// Build the new query string
+		$new_query = http_build_query($query_params);
+		
+		// Construct the new URL
+		$new_url = $url_parts['path'] . (empty($new_query) ? '' : '?' . $new_query);
+
+		$params           = array_merge( $_GET, array( 'purge_wp_easy' => '1' ) );
+		$new_query_string = http_build_query( $params );
+
+		$admin_bar->add_menu(
+			array(
+				'id'    => 'wp-easy-purge-component-styles',
+				'title' => 'Purse Component Styles',
+				'link'  => 
+			)
+		);
+	}
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -20,39 +20,46 @@ class Settings {
 	 */
 	public function init() {
 		add_action( 'admin_bar_menu', array( $this, 'add_purge_link' ), 1000 );
+		add_action( 'init', array( $this, 'purge_cache' ) );
 	}
 
+	/**
+	 * Adds purge link to adminbar menu.
+	 */
 	public function add_purge_link( $admin_bar ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return; // security check.
 		}
 
-		$current_url = (isset($_SERVER['HTTPS']) ? "https://" : "http://") . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$current_url = ( isset( $_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
 		// Parse the URL into components
-		$url_parts = parse_url($current_url);
-		
+		$url_parts = parse_url( $current_url );
+
 		// Parse existing query parameters
-		parse_str($url_parts['query'] ?? '', $query_params);
+		parse_str( $url_parts['query'] ?? '', $query_params );
 
 		// Add/modify the parameter
-		$query_params[$param_name] = $param_value;
+		$query_params['purge-wp-easy'] = '1';
 
-		// Build the new query string
-		$new_query = http_build_query($query_params);
-		
-		// Construct the new URL
-		$new_url = $url_parts['path'] . (empty($new_query) ? '' : '?' . $new_query);
-
-		$params           = array_merge( $_GET, array( 'purge_wp_easy' => '1' ) );
-		$new_query_string = http_build_query( $params );
+		$new_query = http_build_query( $query_params );
+		$new_url   = $url_parts['path'] . ( empty( $new_query ) ? '' : '?' . $new_query );
 
 		$admin_bar->add_menu(
 			array(
 				'id'    => 'wp-easy-purge-component-styles',
-				'title' => 'Purse Component Styles',
-				'link'  => 
+				'title' => 'Purge WP Easy',
+				'href'  => $new_url,
 			)
 		);
+	}
+
+	/**
+	 * Purge cache.
+	 */
+	public function purge_cache() {
+		if ( isset( $_GET['purge-wp-easy'] ) ) {
+			Utils::purge_component_styles();
+		}
 	}
 }

--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -9,7 +9,7 @@
 namespace WpEasy;
 
 /**
- * Class Utils
+ * Class Template
  *
  * @package WpEasy
  */
@@ -61,8 +61,10 @@ class Template {
 	public function enqueue_styles() {
 
 		// Build site SCSS file.
-		Utils::compile_site_styles( Utils::is_debug_mode() );
+		$compiled_site_style = Utils::compile_site_styles( Utils::is_debug_mode() );
+		wp_enqueue_style( 'wp-easy-scss-compiled', $compiled_site_style['url'], [], $compiled_site_style['version'] );
 
+		// Enqueue all CSS files in styles directory.
 		$css_files = glob( get_template_directory() . '/styles/' . '*.css' );
 		sort( $css_files, SORT_STRING | SORT_FLAG_CASE );
 


### PR DESCRIPTION
- Moved compiled CSS and JS files to `/wp-content/uploads/wp-easy-dist/` directory ( fix #32 )
- Added `Purge WP Easy` button to adminbar to purge components style cache.
- Updated caching feature.
- Added throwing error on SCSS build failed in debug mode ( fix #33 )